### PR TITLE
Adding pending order section to AdminDashboard.tsx

### DIFF
--- a/hackathon_site/dashboard/frontend/src/components/orders/OrderCard/OrderCard.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/orders/OrderCard/OrderCard.tsx
@@ -14,7 +14,10 @@ const OrderCard = ({ teamCode, orderQuantity, time, id, status }: OrderProps) =>
     const date = new Date(time);
     const month = date.toLocaleString("default", { month: "short" });
     const day = date.getDate();
-    const hoursAndMinutes = date.getHours() + ":" + date.getMinutes();
+    const hoursAndMinutes = 
+        date.getHours() +
+        ":" +
+        ((date.getMinutes() < 10 ? "0" : "") + date.getMinutes());
 
     const orderDetails = [
         { title: "Team", value: teamCode },

--- a/hackathon_site/dashboard/frontend/src/components/orders/OrderCard/OrderCard.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/orders/OrderCard/OrderCard.tsx
@@ -14,7 +14,7 @@ const OrderCard = ({ teamCode, orderQuantity, time, id, status }: OrderProps) =>
     const date = new Date(time);
     const month = date.toLocaleString("default", { month: "short" });
     const day = date.getDate();
-    const hoursAndMinutes = 
+    const hoursAndMinutes =
         date.getHours() +
         ":" +
         ((date.getMinutes() < 10 ? "0" : "") + date.getMinutes());

--- a/hackathon_site/dashboard/frontend/src/pages/AdminDashboard/AdminDashboard.module.scss
+++ b/hackathon_site/dashboard/frontend/src/pages/AdminDashboard/AdminDashboard.module.scss
@@ -1,0 +1,24 @@
+@import "assets/abstracts/mixins";
+@import "assets/abstracts/variables";
+
+.titleButton {
+    margin-left: 45px;
+}
+
+.title {
+    text-justify: left;
+    margin-bottom: 10px;
+    font-family: "Roboto";
+    font-style: normal;
+    font-weight: 500;
+    font-size: 16px;
+    line-height: 19px;
+}
+
+.dashboard {
+    width: 100%;
+}
+
+.section {
+    margin-bottom: 1rem;
+}

--- a/hackathon_site/dashboard/frontend/src/pages/AdminDashboard/AdminDashboard.test.tsx
+++ b/hackathon_site/dashboard/frontend/src/pages/AdminDashboard/AdminDashboard.test.tsx
@@ -7,7 +7,7 @@ import { within } from "testing/utils";
 import { mockPendingOrders } from "testing/mockData";
 
 describe("Admin Dashboard Page", () => {
-  let store: RootStore;
+    let store: RootStore;
 
     beforeEach(() => {
         store = makeStoreWithEntities({

--- a/hackathon_site/dashboard/frontend/src/pages/AdminDashboard/AdminDashboard.test.tsx
+++ b/hackathon_site/dashboard/frontend/src/pages/AdminDashboard/AdminDashboard.test.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import AdminDashboard from "pages/AdminDashboard/AdminDashboard";
+
+import { makeStoreWithEntities, render, waitFor } from "testing/utils";
+import { RootStore } from "slices/store";
+import { within } from "testing/utils";
+import { mockPendingOrders } from "testing/mockData";
+
+describe("Admin Dashboard Page", () => {
+  let store: RootStore;
+
+    beforeEach(() => {
+        store = makeStoreWithEntities({
+            allOrders: mockPendingOrders,
+        });
+    });
+    test("Display correct order cards", () => {
+        const { getByText, getByTestId } = render(<AdminDashboard />, { store });
+        mockPendingOrders.forEach((order) => {
+            const orderStatus = order.status;
+
+            if (orderStatus === "Submitted" || orderStatus === "Ready for Pickup") {
+                const orderItem = getByTestId(`order-item-${order.id}`);
+                const orderDetails = within(orderItem);
+                const date = new Date(order.updated_at);
+                const month = date.toLocaleString("default", { month: "short" });
+                const day = date.getDate();
+                const hoursAndMinutes =
+                    date.getHours() +
+                    ":" +
+                    ((date.getMinutes() < 10 ? "0" : "") + date.getMinutes());
+
+                expect(orderDetails.getByText(order.team_code)).toBeInTheDocument();
+                expect(orderDetails.getByText(order.items.length)).toBeInTheDocument();
+                expect(orderDetails.getByText(order.id)).toBeInTheDocument();
+                expect(orderDetails.getByText(order.status)).toBeInTheDocument();
+                expect(
+                    orderDetails.getByText(`${month} ${day}, ${hoursAndMinutes}`)
+                ).toBeInTheDocument();
+            }
+        });
+    });
+
+    test("Renders correctly when the dashboard appears with Title texts", async () => {
+        const { getByText } = render(<AdminDashboard />);
+
+        await waitFor(() => {
+            expect(getByText("Hackathon Name Admin Dashboard")).toBeInTheDocument();
+            expect(getByText("Overview")).toBeInTheDocument();
+            expect(getByText("Pending Orders")).toBeInTheDocument();
+        });
+    });
+});

--- a/hackathon_site/dashboard/frontend/src/pages/AdminDashboard/AdminDashboard.tsx
+++ b/hackathon_site/dashboard/frontend/src/pages/AdminDashboard/AdminDashboard.tsx
@@ -2,12 +2,86 @@ import React from "react";
 import Typography from "@material-ui/core/Typography";
 import Header from "components/general/Header/Header";
 import { hackathonName } from "constants.js";
+import OrderCard from "components/orders/OrderCard/OrderCard";
+import { useDispatch, useSelector } from "react-redux";
+import styles from "./AdminDashboard.module.scss";
+import Grid from "@material-ui/core/Grid";
+import Button from "@material-ui/core/Button";
+import {
+    adminOrderSelectors,
+    getOrdersWithFilters,
+    setFilters,
+} from "slices/order/adminOrderSlice";
+import { OrderFilters } from "api/types";
+import { useHistory } from "react-router-dom";
 
 const AdminDashboard = () => {
+    const dispatch = useDispatch();
+    const history = useHistory();
+    const allOrders = useSelector(adminOrderSelectors.selectAll);
+    const pendingFilter: OrderFilters = {
+        status: ["Submitted", "Ready for Pickup"],
+    };
+    dispatch(setFilters(pendingFilter));
+    dispatch(getOrdersWithFilters());
+    const numOrdersOnPage = 6;
+    const ordersLength =
+        allOrders.length <= numOrdersOnPage ? allOrders.length : numOrdersOnPage;
     return (
         <>
             <Header />
             <Typography variant="h1">{hackathonName} Admin Dashboard</Typography>
+            <Grid className={styles.dashboard}>
+                <div className={styles.section}>
+                    <Typography className={styles.title}>Overview</Typography>
+                </div>
+
+                <div className={styles.section}>
+                    <Typography className={styles.title}>
+                        Pending Orders
+                        <Button
+                            color="primary"
+                            href="/orders"
+                            className={styles.titleButton}
+                        >
+                            VIEW ALL
+                        </Button>
+                    </Typography>
+                    <Grid
+                        container
+                        spacing={2}
+                        direction="row"
+                        justifyContent="flex-start"
+                    >
+                        {allOrders.slice(0, ordersLength).map((order, idx) => (
+                            <Grid
+                                item
+                                lg={2}
+                                md={3}
+                                sm={4}
+                                xs={12}
+                                key={idx}
+                                onClick={() =>
+                                    history.push(`/teams/${order.team_code}`)
+                                }
+                            >
+                                {["Submitted", "Ready for Pickup"].includes(
+                                    order.status
+                                ) && (
+                                    <OrderCard
+                                        teamCode={order.team_code}
+                                        orderQuantity={order.items.length}
+                                        time={order.updated_at}
+                                        id={order.id}
+                                        status={order.status}
+                                        data-testid={`order-item-${order.id}`}
+                                    />
+                                )}
+                            </Grid>
+                        ))}
+                    </Grid>
+                </div>
+            </Grid>
         </>
     );
 };


### PR DESCRIPTION
## Overview

- Resolves 256 Create Pending Order Section on the HSS Admin Dashboard
- Creating pending orders section on the hardware admin dashboard page
- Using MUI grid to layout the OrderCards for pending orders


## Unit Tests Created

- Created AdminDashboard.test.tsx that checks for titles in the Admin dashboard


## Steps to QA

-

## View of Final Page

![image](https://github.com/ieeeuoft/newhacks-site-2023/assets/54194957/b51710ae-a587-46e7-9d8c-477f0b2fd4e2)

The page only shows up to 6 pending order cards.

